### PR TITLE
added Miro link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ https://youtu.be/jWYKGHW4QVU
 ### Check out team.md:
 
 https://github.com/cse110-sp25-group04/cse110-sp25-group04/blob/main/admin/team.md
+
+## Check out our art board:
+
+https://miro.com/app/board/uXjVI44JcyM=/?share_link_id=705948852757


### PR DESCRIPTION
I added the Miro page to our README.md so that developers and viewers can easily find the wireframe and design brainstorming for our project.